### PR TITLE
Upgrade urllib3 from 1.22 to latest version (1.24.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ python-dateutil==2.6.1
 requests==2.20.0
 s3transfer==0.1.12
 six==1.11.0
-urllib3==1.22
+urllib3==1.24.1
 virtualenv==15.1.0


### PR DESCRIPTION
This update addresses a 'high severity' security concern raised by GitHub by upgrading urllib3 from 1.22 to the most recent and stable version (1.24.1).